### PR TITLE
Lua5.2 has more strict checking for string.find pattern

### DIFF
--- a/src/cgilua/authentication.lua
+++ b/src/cgilua/authentication.lua
@@ -197,8 +197,8 @@ end
 function M.refURL()
     local url
     local baseURL = cgilua.QUERY.ref or configuration.checkURL
-    if string.find(baseURL, "\?") then
-        url = string.gsub(baseURL, "\?", "?"..configuration.tokenName.."="..cryptUserData().."&")
+    if string.find(baseURL, "%?") then
+        url = string.gsub(baseURL, "%?", "?"..configuration.tokenName.."="..cryptUserData().."&")
     else
         url = baseURL.."?"..configuration.tokenName.."="..cryptUserData()
     end


### PR DESCRIPTION
Hi, 

When I am testing the cgilua, I got the error about string.find invalid escape:

/usr/local/share/lua/5.2/luarocks/loader.lua:113: error loading module 'cgilua.authentication' from file '/usr/local/share/lua/5.2/cgilua/authentication.lua':
    /usr/local/share/lua/5.2/cgilua/authentication.lua:200: invalid escape sequence near '\?'
stack traceback:
    [C]: in function 'loader'
    /usr/local/share/lua/5.2/luarocks/loader.lua:113: in function </usr/local/share/lua/5.2/luarocks/loader.lua:110>
    (...tail calls...)
    [C]: in function 'require'
    ...cgilua-master/examples/cgilua/../authentication_conf.lua:9: in main chunk
    [C]: in function 'xpcall'
    /usr/local/share/lua/5.2/cgilua.lua:174: in function </usr/local/share/lua/5.2/cgilua.lua:173>
    (...tail calls...)
    ...�载/source/Lua/cgilua-master/examples/cgilua/config.lua:11: in main chunk
    [C]: in function 'xpcall'
    /usr/local/share/lua/5.2/cgilua.lua:174: in function </usr/local/share/lua/5.2/cgilua.lua:173>
    (...tail calls...)
    /usr/local/share/lua/5.2/cgilua/loader.lua:16: in function 'init'
    /usr/local/share/lua/5.2/cgilua.lua:614: in function 'main'
    /usr/local/share/lua/5.2/wsapi/sapi.lua:53: in function </usr/local/share/lua/5.2/wsapi/sapi.lua:6>
    (...tail calls...)
    [C]: in function 'xpcall'
    /usr/local/share/lua/5.2/wsapi/common.lua:264: in function 'run_app'
    [string "  local app_name, bootstrap_code, is_file = ...."]:67: in function <[string "  local app_name, bootstrap_code, is_file = ...."]:64> 127.0.0.1 Wed Dec  4 23:39:36 2013
