### PR TITLE
Enabled accepting all unsupported POST content types as plain text

### DIFF
--- a/src/cgilua/post.lua
+++ b/src/cgilua/post.lua
@@ -286,10 +286,9 @@ return {
 			urlcode.parsequery (read (inputsize), defs.args)
 		elseif strfind(contenttype, "multipart/form-data", 1, true) then
 			Main (inputsize, defs.args)
-		elseif strfind (contenttype, "application/xml", 1, true) or strfind (contenttype, "text/xml", 1, true) or strfind (contenttype, "text/plain", 1, true) then
-			tinsert (defs.args, read (inputsize))
 		else
-			error("Unsupported Media Type: "..contenttype)
+			local input = read(inputsize)
+			tinsert (defs.args, input)
 		end
 	end,
 }


### PR DESCRIPTION
I am not 100% positive this change is trouble free, but it is required for one of my recent forks: https://github.com/pdxmeshnet/jsonrpc4lua
